### PR TITLE
Give a default to message variable

### DIFF
--- a/FireLogger.php
+++ b/FireLogger.php
@@ -90,7 +90,7 @@
             $this->log(Psr\Log\LogLevel::WARNING, $message, $context);
         }
 
-        public function log($level, $message, array $context = array() ) {
+        public function log($level, $message = "", array $context = array() ) {
             switch($level) {
                 case \Psr\Log\LogLevel::WARNING:
                 case \Psr\Log\LogLevel::ALERT:


### PR DESCRIPTION
![screen shot 2016-06-02 at 14 35 14](https://cloud.githubusercontent.com/assets/10948793/15744979/9afb0412-28cf-11e6-98a5-75d62fee2c48.png)
Under certain circumstances this throws an error in FireLogger itself. Providing a default gets rid of the error. Not 100% sure what actually is the root cause of the problem but this is the fix
